### PR TITLE
Add ext types

### DIFF
--- a/src/main/scala/msgpack4z/MsgpackUnionOrder.scala
+++ b/src/main/scala/msgpack4z/MsgpackUnionOrder.scala
@@ -104,7 +104,7 @@ private[msgpack4z] object MsgpackUnionOrder extends Order[MsgpackUnion] {
       }
     case MsgpackULong(xx) =>
       y match {
-        case (_: MsgpackMap) | (_: MsgpackArray) | MsgpackExt =>
+        case (_: MsgpackMap) | (_: MsgpackArray) | (_: MsgpackExt) =>
           GT
         case MsgpackULong(yy) =>
           Order[BigInteger].order(xx, yy)
@@ -113,7 +113,7 @@ private[msgpack4z] object MsgpackUnionOrder extends Order[MsgpackUnion] {
       }
     case MsgpackArray(xx) =>
       y match {
-        case (_: MsgpackMap) | MsgpackExt =>
+        case (_: MsgpackMap) | (_: MsgpackExt) =>
           GT
         case MsgpackArray(yy) =>
           UnionListOrder.order(xx, yy)
@@ -122,17 +122,21 @@ private[msgpack4z] object MsgpackUnionOrder extends Order[MsgpackUnion] {
       }
     case MsgpackMap(xx) =>
       y match {
-        case MsgpackExt =>
+        case (_: MsgpackExt) =>
           GT
         case MsgpackMap(yy) =>
           UnionMapOrder.order(xx, yy)
         case _ =>
           LT
       }
-    case MsgpackExt =>
+    case MsgpackExt(xtype, xdata) =>
       y match {
-        case MsgpackExt =>
-          EQ
+        case MsgpackExt(ytype, ydata) =>
+          val res = Order[Byte].order(xtype, ytype)
+          if (res == EQ)
+            order(xdata, ydata)
+          else
+            res
         case _ =>
           LT
       }


### PR DESCRIPTION
See also PRs against [api](https://github.com/msgpack4z/msgpack4z-api/pull/1) and [java07](https://github.com/msgpack4z/msgpack4z-java07/pull/1)

This doesn't include any tests yet. Also, I removed `val ext` in `object MsgpackUnion`, because that seems to be dead code and I couldn't find out what it is supposed to do. The same applies for changes to `abstract class MsgpackUnion`, there are no tests which use that code.

I also updated the version numbers, because I would like to see that you publish a new version. ;)

Fixes #2 